### PR TITLE
Note Go version requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Modify this README to describe:
 
 ## Creating a Pulumi Terraform Bridge Provider
 
+*Note: Go 1.12 is needed to build Pulumi providers using Go Modules. Currently, we recommend pinning the version in `.travis.yml` to `1.12.1` to work around an issue with running later versions on Travis CI.*
+
 First, clone this repo with the name of the desired provider in place of `xyz`:
 
 ```


### PR DESCRIPTION
This came up in the community chat when @igorshapiro was working on porting the DataDog provider.