### PR TITLE
Update API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ The following configuration points are available for the `xyz` provider:
 For detailed reference documentation, please visit [the API docs][1].
 
 
-[1]: https://pulumi.io/reference/pkg/nodejs/@pulumi/x/index.html
+[1]: https://pulumi.io/reference/pkg/nodejs/pulumi/x/


### PR DESCRIPTION
With the [move to Hugo](https://github.com/pulumi/docs/pull/1088), all new package docs will be under `.../pulumi/*` instead of `.../@pulumi/*`. (Older links to existing packages under `@pulumi` will continue to work and redirect.)