### PR TITLE
Add prepare command to rename the `xyz` occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 0.x.x (unreleased)
+CHANGELOG
+=========
 
-### Major Changes
+## HEAD (Unreleased)
+* Add prepare command to rename the `xyz` occurrences
 
-### Improvements
+---
+

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,28 @@ PYPI_VERSION    := $(shell scripts/get-py-version)
 
 TESTPARALLELISM := 4
 
+OS := $(shell uname)
+EMPTY_TO_AVOID_SED := ""
+
+prepare::
+	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi
+	@if test -z "${REPOSITORY}"; then echo "REPOSITORY not set"; exit 1; fi
+	@if test ! -d "cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz"; then "Project already prepared"; exit 1; fi
+
+	mv "cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz" cmd/pulumi-tfgen-${NAME}
+	mv "cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" cmd/pulumi-resource-${NAME}
+
+	if [[ "${OS}" != "Darwin" ]]; then \
+		sed -i 's,github.com/pulumi/pulumi-xyz,${REPOSITORY},g' go.mod; \
+		find ./ ! -path './.git/*' -type f -exec sed -i 's/[x]yz/${NAME}/g' {} \; &> /dev/null; \
+	fi
+
+	# In MacOS the -i parameter needs an empty string to execute in place.
+	if [[ "${OS}" == "Darwin" ]]; then \
+		sed -i '' 's,github.com/pulumi/pulumi-xyz,${REPOSITORY},g' go.mod; \
+		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${NAME}/g' {} \; &> /dev/null; \
+	fi
+
 # NOTE: Since the plugin is published using the nodejs style semver version
 # We set the PLUGIN_VERSION to be the same as the version we use when building
 # the provider (e.g. x.y.z-dev-... instead of x.y.zdev...)

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ First, clone this repo with the name of the desired provider in place of `xyz`:
 git clone https://github.com/pulumi/pulumi-tf-provider-boilerplate pulumi-xyz
 ```
 
-Next, replace references to `xyz` with the name of your provider:
-- Search/replace the string `xyz` with the name of your provider throughout this repo
-- List the configuration points for the provider in the area of the README
-- Rename the `cmd/pulumi-{resource,tfgen}-xyz` directories to match the provider name
-- Replace the module name in `go.mod` to reflect the repository name.
-- If the pulumi provider name differs from the Terraform provider name, set
-  `TF_NAME` in `Makefile` to the Terraform name, leaving `PACK` set to the
-  Pulumi name.
+Second, replace references to `xyz` with the name of your provider:
+
+```
+make prepare NAME=foo REPOSITORY=github.com/pulumi/pulumi-foo
+```
+
+Next, list the configuration points for the provider in the area of the README.
+
 
 > Note: If the name of the desired Pulumi provider differs from the name of the Terraform provider, you will need to carefully distinguish between the references - see https://github.com/pulumi/pulumi-azure for an example.
 


### PR DESCRIPTION
I added the `make prepare` command in order to simplify the renaming of the files and its contents. This expect two arguments, `NAME` and `REPOSITORY`.