### PR TITLE
Update min pulumi version for python

### DIFF
--- a/resources.go
+++ b/resources.go
@@ -145,7 +145,7 @@ func Provider() tfbridge.ProviderInfo {
 		Python: &tfbridge.PythonInfo{
 			// List any Python dependencies and their version ranges
 			Requires: map[string]string{
-				"pulumi": ">=0.16.4,<0.17.0",
+				"pulumi": ">=0.17.28",
 			},
 		},
 	}


### PR DESCRIPTION
```shell
$ pulumi-tfgen-github python --overlays overlays/python/ --out sdk/python/
```

was failing with the following error:

```
error: failed to generate package: lower version bound must be at least 0.17.28
```

Not sure when the lower bound was added, but this PR updates the repo to reflect that.