### PR TITLE
Update the API docs link to use the resource docs link format

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ The following configuration points are available for the `xyz` provider:
 For detailed reference documentation, please visit [the API docs][1].
 
 
-[1]: https://pulumi.io/reference/pkg/nodejs/pulumi/x/
+[1]: https://www.pulumi.com/docs/reference/pkg/x/


### PR DESCRIPTION
We should also update the links in all of the provider repos to link to the resource docs rather than the Node.js docs.