### PR TITLE
fix: use sh instead of bash

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -90,7 +90,7 @@
 #
 # Importing common.mk should be the first thing your Makefile does, after
 # optionally setting SUB_PROJECTS, PROJECT_NAME and NODE_MODULE_NAME.
-SHELL       := /bin/bash
+SHELL       := /bin/sh
 .SHELLFLAGS := -ec
 
 STEP_MESSAGE = @echo -e "\033[0;32m$(shell echo '$@' | tr a-z A-Z | tr '_' ' '):\033[0m"

--- a/scripts/get-py-version
+++ b/scripts/get-py-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -o nounset -o errexit -o pipefail
 
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -o nounset -o errexit -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 COMMITISH=${1:-HEAD}

--- a/scripts/publish-plugin.sh
+++ b/scripts/publish-plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # publish-plugin.sh builds and publishes a package containing the resource provider to
 # s3://rel.pulumi.com/releases/plugins.
 set -o nounset -o errexit -o pipefail

--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # publish_tgz.sh builds and publishes the tarballs that our other repositories consume.
 set -o nounset -o errexit -o pipefail
 


### PR DESCRIPTION
Small change to make sure it runs on NixOS and other linux distributions that come without bash under /bin/bash. There is no dependency on bash for the build scripts but rather for shell which bash is a superset of, /bin/sh is POXIS compliant where /bin/bash is not.