### PR TITLE
Removing the download plugin step for examples generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ TFGEN           := pulumi-tfgen-${PACK}
 PROVIDER        := pulumi-resource-${PACK}
 VERSION         := $(shell scripts/get-version)
 PYPI_VERSION    := $(shell cd scripts && ./get-py-version)
-LATEST_RESOURCE_PROVIDER_VERSION := $(shell curl --silent "https://api.github.com/repos/pulumi/pulumi-${PACK}/tags" | jq ".[0]".name -r)
-PROVIDER_VERSION := ${LATEST_RESOURCE_PROVIDER_VERSION:v%=%}
 
 DOTNET_PREFIX  := $(firstword $(subst -, ,${VERSION:v%=%})) # e.g. 1.5.0
 DOTNET_SUFFIX  := $(word 2,$(subst -, ,${VERSION:v%=%}))    # e.g. alpha.1
@@ -82,7 +80,6 @@ provider:: generate_schema
 
 install_plugins::
 	[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh
-	pulumi plugin install resource $(PACK) $(PROVIDER_VERSION)
 
 install::
 	[ ! -e "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)" ] || rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -6,6 +6,6 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v12.4.3+inc
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
-	github.com/pulumi/pulumi-terraform-bridge/v2 v2.3.3
-	github.com/pulumi/pulumi/sdk/v2 v2.2.1
+	github.com/pulumi/pulumi-terraform-bridge/v2 v2.5.4
+	github.com/pulumi/pulumi/sdk/v2 v2.5.0
 )


### PR DESCRIPTION
Fixes: #37

We no longer depend on an old binary to help generate the schema and examples - this is taken care of in 2 steps in the schema gen now