### PR TITLE
Update README and Makefile to make them easier to use for community provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- `make prepare` replaces "xyz" to providers name properly
 ---

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ prepare::
 	@if test -z "${PROJECT}"; then echo "PROJECT not set"; exit 1; fi
 	@if test ! -d "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz"; then "Project already prepared"; exit 1; fi
 
+	GO111MODULE=on go get github.com/pulumi/pulumi-terraform@master
+	(cd provider && go get ${TF_REPO})
+	(cd provider && go mod download)
+
 	mv "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-tfgen-${PACK}
 	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${PACK}
 

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,14 @@ prepare::
 	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${PACK}
 
 	if [[ "${OS}" != "Darwin" ]]; then \
-		sed -i '' 's,github.com/terraform-providers/terraform-provider-xyz/xyz,${TF_REPO}/${TF_NAME},g' provider/resources.go \
+		sed -i 's,github.com/terraform-providers/terraform-provider-xyz/xyz,${TF_REPO}/${TF_NAME},g' provider/resources.go \
 		find ./ ! -path './.git/*' -type f -exec sed -i 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' {} \; &> /dev/null; \
 		find ./ ! -path './.git/*' -type f -exec sed -i 's/xyz/${PACK}/g' {} \; &> /dev/null; \
 	fi
 
 	# In MacOS the -i parameter needs an empty string to execute in place.
 	if [[ "${OS}" == "Darwin" ]]; then \
+		sed -i '' 's,github.com/terraform-providers/terraform-provider-xyz/xyz,${TF_REPO}/${TF_NAME},g' provider/resources.go \
 		find ./ ! -path './.git/*' -type f -exec sed -i '' 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' {} \; &> /dev/null; \
 		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/xyz/${PACK}/g' {} \; &> /dev/null; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PROJECT_NAME := xyz Package
-
 PACK             := xyz
 ORG              := pulumi
 PROJECT          := github.com/${ORG}/pulumi-${PACK}
@@ -20,25 +18,25 @@ OS := $(shell uname)
 EMPTY_TO_AVOID_SED := ""
 
 prepare::
-	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi
-	@if test -z "${REPOSITORY}"; then echo "REPOSITORY not set"; exit 1; fi
+	@if test -z "${PACK}"; then echo "PACK not set"; exit 1; fi
+	@if test -z "${PROJECT}"; then echo "PROJECT not set"; exit 1; fi
 	@if test ! -d "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz"; then "Project already prepared"; exit 1; fi
 
-	mv "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-tfgen-${NAME}
-	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${NAME}
+	mv "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-tfgen-${PACK}
+	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${PACK}
 
 	if [[ "${OS}" != "Darwin" ]]; then \
-		sed -i 's,github.com/pulumi/pulumi-xyz,${REPOSITORY},g' provider/go.mod; \
-		find ./ ! -path './.git/*' -type f -exec sed -i 's/[x]yz/${NAME}/g' {} \; &> /dev/null; \
+		sed -i 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' provider/go.mod; \
+		find ./ ! -path './.git/*' -type f -exec sed -i 's/[x]yz/${PACK}/g' {} \; &> /dev/null; \
 	fi
 
 	# In MacOS the -i parameter needs an empty string to execute in place.
 	if [[ "${OS}" == "Darwin" ]]; then \
-		sed -i '' 's,github.com/pulumi/pulumi-xyz,${REPOSITORY},g' provider/go.mod; \
-		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${NAME}/g' {} \; &> /dev/null; \
+		sed -i '' 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' provider/go.mod; \
+		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${PACK}/g' {} \; &> /dev/null; \
 
-		sed -i '' 's,github.com/pulumi/pulumi-xyz,${REPOSITORY},g' provider/resources.go; \
-		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${NAME}/g' {} \; &> /dev/null; \
+		sed -i '' 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' provider/resources.go; \
+		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${PACK}/g' {} \; &> /dev/null; \
 	fi
 
 .PHONY: development provider build_sdks build_nodejs build_dotnet build_go build_python cleanup

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ORG              := pulumi
 PROJECT          := github.com/${ORG}/pulumi-${PACK}
 NODE_MODULE_NAME := @pulumi/${PACK}
 TF_NAME          := ${PACK}
+TF_REPO          := github.com/terraform-providers/${PACK}
 PROVIDER_PATH    := provider
 VERSION_PATH     := ${PROVIDER_PATH}/pkg/version.Version
 
@@ -26,17 +27,15 @@ prepare::
 	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${PACK}
 
 	if [[ "${OS}" != "Darwin" ]]; then \
-		sed -i 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' provider/go.mod; \
-		find ./ ! -path './.git/*' -type f -exec sed -i 's/[x]yz/${PACK}/g' {} \; &> /dev/null; \
+		sed -i '' 's,github.com/terraform-providers/terraform-provider-xyz/xyz,${TF_REPO}/${TF_NAME},g' provider/resources.go \
+		find ./ ! -path './.git/*' -type f -exec sed -i 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' {} \; &> /dev/null; \
+		find ./ ! -path './.git/*' -type f -exec sed -i 's/xyz/${PACK}/g' {} \; &> /dev/null; \
 	fi
 
 	# In MacOS the -i parameter needs an empty string to execute in place.
 	if [[ "${OS}" == "Darwin" ]]; then \
-		sed -i '' 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' provider/go.mod; \
-		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${PACK}/g' {} \; &> /dev/null; \
-
-		sed -i '' 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' provider/resources.go; \
-		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/[x]yz/${PACK}/g' {} \; &> /dev/null; \
+		find ./ ! -path './.git/*' -type f -exec sed -i '' 's,github.com/pulumi/pulumi-xyz,${PROJECT},g' {} \; &> /dev/null; \
+		find ./ ! -path './.git/*' -type f -exec sed -i '' 's/xyz/${PACK}/g' {} \; &> /dev/null; \
 	fi
 
 .PHONY: development provider build_sdks build_nodejs build_dotnet build_go build_python cleanup

--- a/README.md
+++ b/README.md
@@ -21,23 +21,23 @@ git clone https://github.com/pulumi/pulumi-tf-provider-boilerplate pulumi-xyz
 Second, replace references to `xyz` with the name of your provider:
 
 ```
-make prepare NAME=foo REPOSITORY=github.com/pulumi/pulumi-foo
+make prepare PACK=foo PROJECT=github.com/pulumi/pulumi-foo
 ```
 
 Next, list the configuration points for the provider in the area of the README.
-
 
 > Note: If the name of the desired Pulumi provider differs from the name of the Terraform provider, you will need to carefully distinguish between the references - see https://github.com/pulumi/pulumi-azure for an example.
 
 ### Add dependencies
 
 In order to properly build the sdks, the following tools are expected:
+
 - `pulumictl` (See the project's README for installation instructions: https://github.com/pulumi/pulumictl)
 
 In the root of the repository, run:
 
 - `GO111MODULE=on go get github.com/pulumi/pulumi-terraform@master`
-- `(cd provider && go get github.com/terraform-providers/terraform-provider-foo)`  (where `foo` is the name of the provider - note the parenthesis to run this in a subshell)
+- `(cd provider && go get github.com/terraform-providers/terraform-provider-foo)` (where `foo` is the name of the provider - note the parenthesis to run this in a subshell)
 - `(cd provider && go mod download)`
 
 ### Build the provider:
@@ -81,6 +81,5 @@ The following configuration points are available for the `xyz` provider:
 ## Reference
 
 For detailed reference documentation, please visit [the API docs][1].
-
 
 [1]: https://www.pulumi.com/docs/reference/pkg/x/

--- a/README.md
+++ b/README.md
@@ -18,11 +18,20 @@ First, clone this repo with the name of the desired provider in place of `xyz`:
 git clone https://github.com/pulumi/pulumi-tf-provider-boilerplate pulumi-xyz
 ```
 
-Second, replace references to `xyz` with the name of your provider:
+Second, prepare your repo for development. This commands replace references to `xyz` with the name of your provider, adds terraform module as dependency and download it.
 
 ```
 make prepare PACK=foo PROJECT=github.com/pulumi/pulumi-foo
+
 ```
+
+| arguments | meaning                          | default value                          |
+| -         | -                                | -                                      |
+| PACK      | provider name                    | xyz                                    |
+| ORG       | github organization or user      | pulumi                                 |
+| PROJECT   | providers github repository      | github.com/${ORG}/pulumi-${PACK}       |
+| TF_NAME   | original terraform module        | $PACK                                  |
+| TF_REPO   | repository with terraform module | github.com/terraform-providers/${PACK} |
 
 Next, list the configuration points for the provider in the area of the README.
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ In order to properly build the sdks, the following tools are expected:
 
 - `pulumictl` (See the project's README for installation instructions: https://github.com/pulumi/pulumictl)
 
-In the root of the repository, run:
-
-- `GO111MODULE=on go get github.com/pulumi/pulumi-terraform@master`
-- `(cd provider && go get github.com/terraform-providers/terraform-provider-foo)` (where `foo` is the name of the provider - note the parenthesis to run this in a subshell)
-- `(cd provider && go mod download)`
-
 ### Build the provider:
 
 - Edit `provider/resources.go` to map each resource, and specify provider information

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ First, clone this repo with the name of the desired provider in place of `xyz`:
 git clone https://github.com/pulumi/pulumi-tf-provider-boilerplate pulumi-xyz
 ```
 
+> Note: If the name of the desired Pulumi provider differs from the name of the Terraform provider, you will need to carefully distinguish between the references - see https://github.com/pulumi/pulumi-azure for an example.
+
 Second, prepare your repo for development. This commands replace references to `xyz` with the name of your provider, adds terraform module as dependency and download it.
 
 ```
 make prepare PACK=foo PROJECT=github.com/pulumi/pulumi-foo
-
 ```
 
 | arguments | meaning                          | default value                          |
@@ -35,7 +36,6 @@ make prepare PACK=foo PROJECT=github.com/pulumi/pulumi-foo
 
 Next, list the configuration points for the provider in the area of the README.
 
-> Note: If the name of the desired Pulumi provider differs from the name of the Terraform provider, you will need to carefully distinguish between the references - see https://github.com/pulumi/pulumi-azure for an example.
 
 ### Add dependencies
 


### PR DESCRIPTION
I've started to a build [provider](https://github.com/aladmit/pulumi-yandex) for Yandex.Cloud  from their [terraform provider](https://github.com/yandex-cloud/terraform-provider-yandex/). There were a huge amount of errors about go modules because they weren't replaced properly.

In this PR I fix xyz replacing and tried to make `prepare` command clearer.