### PR TITLE
Upgrade versions of pulumi and pulumi-terraform-bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build_python:: install_plugins tfgen # build the python sdk
         cp ../../README.md . && \
         python3 setup.py clean --all 2>/dev/null && \
         rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-        sed -i.bak -e "s/\$${VERSION}/$(PYPI_VERSION)/g" -e "s/\$${PLUGIN_VERSION}/$(VERSION)/g" ./bin/setup.py && \
+        sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
         rm ./bin/setup.py.bak && \
         cd ./bin && python3 setup.py build sdist
 
@@ -104,7 +104,7 @@ clean::
 
 install_plugins::
 	[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh
-	pulumi plugin install resource random 2.2.0
+	pulumi plugin install resource random 4.3.1
 
 install_dotnet_sdk::
 	mkdir -p $(WORKING_DIR)/nuget

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,10 +4,11 @@ go 1.16
 
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20210629210550-59d24255d71f
 )
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.2.1
-	github.com/pulumi/pulumi/sdk/v3 v3.4.0
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.9.0
+	github.com/pulumi/pulumi/sdk/v3 v3.14.0
 )

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -20,10 +20,9 @@ import (
 	"unicode"
 
 	"github.com/pulumi/pulumi-xyz/provider/pkg/version"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
-	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1"
+	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/terraform-providers/terraform-provider-xyz/xyz"
@@ -91,7 +90,7 @@ var managedByPulumi = &tfbridge.DefaultInfo{Value: "Managed by Pulumi"}
 // Provider returns additional overlaid schema and metadata associated with the provider..
 func Provider() tfbridge.ProviderInfo {
 	// Instantiate the Terraform provider
-	p := shimv1.NewProvider(xyz.Provider().(*schema.Provider))
+	p := shimv2.NewProvider(xyz.Provider())
 
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -2,4 +2,4 @@ module github.com/pulumi/pulumi-xyz/sdk
 
 go 1.14
 
-require github.com/pulumi/pulumi/sdk/v3 v3.4.0
+require github.com/pulumi/pulumi/sdk/v3 v3.14.0


### PR DESCRIPTION
this will ensure that new providers are adhering to the new codegen
standards. We also now make an assumption that all new mapped providers
will adhere to v2 of the terraform-plugin-sdk
