### PR TITLE
Do not install pulumi automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ clean::
 	rm -rf sdk/{dotnet,nodejs,go,python}
 
 install_plugins::
-	[ -x $(shell which pulumi) ] || curl -fsSL https://get.pulumi.com | sh
 	pulumi plugin install resource random 4.3.1
 
 install_dotnet_sdk::


### PR DESCRIPTION
Pulumi is marked as a requirement, but I do not expect a Makefile to install it for me using `curl | bash`. I would prefer to get an error and figure out myself how to install Pulumi. Notably, if I have an environment with Pulumi but I forgot to switch to it, I don't expect to have another copy installed this way.