### PR TITLE
fix: Explicity specify bash as shell in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PROJECT_NAME := xyz Package
 
+SHELL            := /bin/bash
 PACK             := xyz
 ORG              := pulumi
 PROJECT          := github.com/${ORG}/pulumi-${PACK}


### PR DESCRIPTION
Background
---
As the Makefile uses bash builtins, e.g. `[[`, `]]` -- explicitly set the shell to bash

Note
---
Although OSX happily defaults to bash, on Ubuntu/Debian it defaults to sh and results in: `/bin/sh: 1: [[: not found`