### PR TITLE
fix: Use correct version of pulumi v3 sdk in go mod

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -10,5 +10,5 @@ replace (
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.9.1
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.18.0
-	github.com/pulumi/pulumi/sdk/v3 v3.24.1.0
+	github.com/pulumi/pulumi/sdk/v3 v3.25.1
 )


### PR DESCRIPTION
Background
---
Invalid semantic version `v3.24.1.0` results in `require github.com/pulumi/pulumi/sdk/v3: version "v3.24.1.0" invalid: unknown revision v3.24.1.0` -- updated to latest valid version `v3.25.1`