### PR TITLE
fix: Update readme -- we need go 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following instructions assume a Pulumi-owned provider based on an upstream p
 Ensure the following tools are installed and present in your `$PATH`:
 
 * [`pulumictl`](https://github.com/pulumi/pulumictl#installation)
-* [Go 1.16](https://golang.org/dl/) or 1.latest
+* [Go 1.17](https://golang.org/dl/) or 1.latest
 * [NodeJS](https://nodejs.org/en/) 14.x.  We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage NodeJS installations.
 * [Yarn](https://yarnpkg.com/)
 * [TypeScript](https://www.typescriptlang.org/)

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-xyz/provider
 
-go 1.16
+go 1.17
 
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0


### PR DESCRIPTION
Background
---
Update README and boilerplate go.mod to set version to go 1.17 per the pulumi dependency:

```
❯ go test -v ./...
# github.com/pulumi/pulumi/pkg/v3/codegen/schema
../../../go/pkg/mod/github.com/pulumi/pulumi/pkg/v3@v3.23.2/codegen/schema/loader.go:120:30: not enough arguments in call to pkgPlugin.Install
        have (*os.File)
        want (io.ReadCloser, bool)
```