### PR TITLE
Revert "Use go:embed instead of go generate for schema"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ only_build:: build
 tfgen:: install_plugins
 	(cd provider && go build -o $(WORKING_DIR)/bin/${TFGEN} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${TFGEN})
 	$(WORKING_DIR)/bin/${TFGEN} schema --out provider/cmd/${PROVIDER}
+	(cd provider && VERSION=$(VERSION) go generate cmd/${PROVIDER}/main.go)
 
 provider:: tfgen install_plugins # build the provider binary
 	(cd provider && go build -o $(WORKING_DIR)/bin/${PROVIDER} -ldflags "-X ${PROJECT}/${VERSION_PATH}=${VERSION}" ${PROJECT}/${PROVIDER_PATH}/cmd/${PROVIDER})

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The following instructions all pertain to `provider/resources.go`, in the sectio
 
     Fix any issues found by the linter.
 
-**Note:** If you make revisions to code in `resources.go`, you must re-run the `make tfgen` target to regenerate the schema.
+**Note:** If you make revisions to code in `resources.go`, you must re-run the `make tfgen` target to regenerate the schema.  Pulumi providers use Go 1.16, which does not have the ability to directly embed text files.  The `make tfgen` target will take the file `schema.json` and serialize it to a byte array so that it can be included in the build output.  (Go 1.17 will remove the need for this step.)
 
 ## Sample Program
 

--- a/provider/cmd/pulumi-resource-xyz/.gitignore
+++ b/provider/cmd/pulumi-resource-xyz/.gitignore
@@ -1,0 +1,1 @@
+schema.go

--- a/provider/cmd/pulumi-resource-xyz/generate.go
+++ b/provider/cmd/pulumi-resource-xyz/generate.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+func main() {
+	version, found := os.LookupEnv("VERSION")
+	if !found {
+		log.Fatal("version not found")
+	}
+
+	schemaContents, err := ioutil.ReadFile("./schema.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var packageSpec schema.PackageSpec
+	err = json.Unmarshal(schemaContents, &packageSpec)
+	if err != nil {
+		log.Fatalf("cannot deserialize schema: %v", err)
+	}
+
+	packageSpec.Version = version
+	versionedContents, err := json.Marshal(packageSpec)
+	if err != nil {
+		log.Fatalf("cannot reserialize schema: %v", err)
+	}
+
+	err = ioutil.WriteFile("./schema.go", []byte(fmt.Sprintf(`package main
+var pulumiSchema = %#v
+`, versionedContents)), 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/provider/cmd/pulumi-resource-xyz/main.go
+++ b/provider/cmd/pulumi-resource-xyz/main.go
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:generate go run ./generate.go
+
 package main
 
 import (
-	_ "embed"
-
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	xyz "github.com/pulumi/pulumi-xyz/provider"
 	"github.com/pulumi/pulumi-xyz/provider/pkg/version"
 )
-
-//go:embed schema.json
-var pulumiSchema []byte
 
 func main() {
 	// Modify the path to point to the new provider


### PR DESCRIPTION
It was brought to my attention that we need to do some house cleaning to have this fully work.

See also: https://github.com/pulumi/home/issues/1765