### PR TITLE
Add details for third-party provider creation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ From the templated repository:
     ```bash
     make prepare NAME=foo REPOSITORY=github.com/pulumi/pulumi-foo
     ```
-   
+
    This will do the following:
    - rename folders in `provider/cmd` to `pulumi-resource-foo` and `pulumi-tfgen-foo`
    - replace dependencies in `provider/go.mod` to reflect your repository name
    - find and replace all instances of the boilerplate `xyz` with the `NAME` of your provider.
 
    Note for third-party (non-pulumi organization) providers:
-   - Make sure to set the correct github organization/username in all files referencing your provider as a dependency:
+   - Make sure to set the correct GitHub organization/username in all files referencing your provider as a dependency:
      - `examples/go.mod`
      - `provider/resources.go`
      - `sdk/go.mod`
@@ -67,8 +67,8 @@ Pulumi provider repositories have the following general structure:
 
 * `examples/` contains sample code which may optionally be included as integration tests to be run as part of a CI/CD pipeline.
 * `provider/` contains the Go code used to create the provider as well as generate the SDKs in the various languages that Pulumi supports.
-  * `provider/cmd/pulumi-tfgen-foo` contains the code to generate the Pulumi resource schema (`schema.json`), based on the Terraform provider's resources. 
-  * `provider/cmd/pulumi-resource-foo` contains the code to generate the code SDKs in all supported languages.
+  * `provider/cmd/pulumi-tfgen-foo` generates the Pulumi resource schema (`schema.json`), based on the Terraform provider's resources.
+  * `provider/cmd/pulumi-resource-foo` generates the SDKs in all supported languages from the schema, placing them in the `sdk/` folder.
   * `provider/pkg/resources.go` is the location where we will define the Terraform-to-Pulumi mappings for resources.
 * `sdk/` contains the generated SDK code for each of the language platforms that Pulumi supports, with each supported platform in a separate subfolder.
 
@@ -203,15 +203,15 @@ The following instructions all pertain to `provider/resources.go`, in the sectio
 
     Fix any issues found by the linter.
 
-**Note:** If you make revisions to code in `resources.go`, you must re-run the `make tfgen` target to regenerate the schema.  
-Pulumi providers use Go 1.16, which does not have the ability to directly embed text files.  
-The `make tfgen` target will take the file `schema.json` and serialize it to a byte array so that it can be included in the build output.  (Go 1.17 will remove the need for this step.)
+**Note:** If you make revisions to code in `resources.go`, you must re-run the `make tfgen` target to regenerate the schema.
+The `make tfgen` target will take the file `schema.json` and serialize it to a byte array so that it can be included in the build output.
+(This is a holdover from Go 1.16, which does not have the ability to directly embed text files. We are working on removing the need for this step.)
 
 ## Sample Program
 
 In this section, we will create a Pulumi program in TypeScript that utilizes the provider we created to ensure everything is working properly.
 
-1. Create an account with the provider's service and generate any necessary credentials, e.g. API keys:
+1. Create an account with the provider's service and generate any necessary credentials, e.g. API keys.
     * Email: bot@pulumi.com
     * Password: (Create a random password in 1Password with the  maximum length and complexity allowed by the provider.)
     * Ensure all secrets (passwords, generated API keys) are stored in Pulumi's 1Password vault.
@@ -292,6 +292,12 @@ We can run integration tests on our examples using the `*_test.go` files in the 
     ```
 
 ## Configuring CI with GitHub Actions
+
+### Third-party providers
+
+1. Follow the instructions laid out in the [deployment templates](./deployment-templates/README-DEPLOYMENT.md).
+
+### Pulumi Internal
 
 In this section, we'll add the necessary configuration to work with GitHub Actions for Pulumi's standard CI/CD workflows for providers.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pulumi offers this repository as a [GitHub template repository](https://docs.git
 1. Click "Use this template".
 1. Set the following options:
     * Owner: pulumi (or your GitHub organization/username)
-    * Repository name: pulumi-foo
+    * Repository name: pulumi-foo (preface your provider with "pulumi" as standard practice)
     * Description: Pulumi provider for Foo
     * Repository type: Public
 1. Clone the generated repository.
@@ -39,8 +39,21 @@ From the templated repository:
     ```bash
     make prepare NAME=foo REPOSITORY=github.com/pulumi/pulumi-foo
     ```
+   
+   This will do the following:
+   - rename folders in `provider/cmd` to `pulumi-resource-foo` and `pulumi-tfgen-foo`
+   - replace dependencies in `provider/go.mod` to reflect your repository name
+   - find and replace all instances of the boilerplate `xyz` with the `NAME` of your provider.
 
-1. Modify `README-PROVIDER.md` to include the following (we'll rename it to `README.md` toward the end of this guide):
+   Note for third-party (non-pulumi organization) providers:
+   - Make sure to set the correct github organization/username in all files referencing your provider as a dependency:
+     - `examples/go.mod`
+     - `provider/resources.go`
+     - `sdk/go.mod`
+     - `provider/cmd/pulumi-resource-foo/main.go`
+     - `provider/cmd/pulumi-tfgen-foo/main.go`
+
+2. Modify `README-PROVIDER.md` to include the following (we'll rename it to `README.md` toward the end of this guide):
     * Any desired build status badges.
     * An introductory paragraph describing the type of resources the provider manages, e.g. "The Foo provider for Pulumi manages resources for [Foo](http://example.com/).
     * In the "Installing" section, correct package names for the various SDK libraries in the languages Pulumi supports.
@@ -54,6 +67,9 @@ Pulumi provider repositories have the following general structure:
 
 * `examples/` contains sample code which may optionally be included as integration tests to be run as part of a CI/CD pipeline.
 * `provider/` contains the Go code used to create the provider as well as generate the SDKs in the various languages that Pulumi supports.
+  * `provider/cmd/pulumi-tfgen-foo` contains the code to generate the Pulumi resource schema (`schema.json`), based on the Terraform provider's resources. 
+  * `provider/cmd/pulumi-resource-foo` contains the code to generate the code SDKs in all supported languages.
+  * `provider/pkg/resources.go` is the location where we will define the Terraform-to-Pulumi mappings for resources.
 * `sdk/` contains the generated SDK code for each of the language platforms that Pulumi supports, with each supported platform in a separate subfolder.
 
 1. In `provider/go.mod`, add a reference to the upstream Terraform provider in the `require` section, e.g.
@@ -74,7 +90,7 @@ Pulumi provider repositories have the following general structure:
     cd provider && go mod tidy && cd -
     ```
 
-1. Validate the schema by running the following command:
+1. Create the schema by running the following command:
 
     ```bash
     make tfgen
@@ -157,7 +173,7 @@ The following instructions all pertain to `provider/resources.go`, in the sectio
         },
     ```
 
-1. Build the provider and ensure there are no warnings about unmapped resources and no warnings about unmapped data sources:
+1. Build the provider binary and ensure there are no warnings about unmapped resources and no warnings about unmapped data sources:
 
     ```bash
     make provider
@@ -187,7 +203,9 @@ The following instructions all pertain to `provider/resources.go`, in the sectio
 
     Fix any issues found by the linter.
 
-**Note:** If you make revisions to code in `resources.go`, you must re-run the `make tfgen` target to regenerate the schema.  Pulumi providers use Go 1.16, which does not have the ability to directly embed text files.  The `make tfgen` target will take the file `schema.json` and serialize it to a byte array so that it can be included in the build output.  (Go 1.17 will remove the need for this step.)
+**Note:** If you make revisions to code in `resources.go`, you must re-run the `make tfgen` target to regenerate the schema.  
+Pulumi providers use Go 1.16, which does not have the ability to directly embed text files.  
+The `make tfgen` target will take the file `schema.json` and serialize it to a byte array so that it can be included in the build output.  (Go 1.17 will remove the need for this step.)
 
 ## Sample Program
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 This repository contains boilerplate code for building a new Pulumi provider which wraps an existing Terraform provider.  
 
-The following instructions cover: 
-- providers maintained by Pulumi (denoted with a "Pulumi Official" checkmark on the Pulumi registry)
-- providers published and maintained by the Pulumi community, referred to as "third-party" providers.
+### Background
+This repository is part of the [guide for authoring and publishing a Pulumi Package](https://www.pulumi.com/docs/guides/pulumi-packages/how-to-author).
+
+Learn about the concepts behind [Pulumi Packages](https://www.pulumi.com/docs/guides/pulumi-packages/#pulumi-packages).
 
 ## Creating a Pulumi Terraform Bridge Provider
 
-The following instructions assume a Pulumi-owned provider based on an upstream provider named `terraform-provider-foo`.  Substitute appropriate values below for your use case.
+The following instructions cover:
+- providers maintained by Pulumi (denoted with a "Pulumi Official" checkmark on the Pulumi registry)
+- providers published and maintained by the Pulumi community, referred to as "third-party" providers
+
+We showcase a Pulumi-owned provider based on an upstream provider named `terraform-provider-foo`.  Substitute appropriate values below for your use case.
 
 > Note: If the name of the desired Pulumi provider differs from the name of the Terraform provider, you will need to carefully distinguish between the references - see <https://github.com/pulumi/pulumi-azure> for an example.
 
@@ -321,7 +326,7 @@ In this section, we'll add the necessary configuration to work with GitHub Actio
     mv README-PROVIDER.md README.md
     ```
 
-1. If publishing the npm package fails during the "Publish SKDs" Action, perform the following steps:
+1. If publishing the npm package fails during the "Publish SDKs" Action, perform the following steps:
     1. Go to [NPM Packages](https://www.npmjs.com/) and sign in as pulumi-bot.
     1. Click on the bot's profile pic and navigate to "Packages".
     1. On the left, under "Organizations, click on the Pulumi organization.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Terraform Bridge Provider Boilerplate
 
-This repository contains boilerplate code for building a new Pulumi provider which wraps an existing Terraform provider.  These instructions are primarily intended for internal use by Pulumi as we have not yet refined the process for general consumption by the community at large, but this document may serve as a rough guide for community members who want to create their own Pulumi providers that wrap an existing Terraform provider.
+This repository contains boilerplate code for building a new Pulumi provider which wraps an existing Terraform provider.  
+
+The following instructions cover: 
+- providers maintained by Pulumi (denoted with a "Pulumi Official" checkmark on the Pulumi registry)
+- providers published and maintained by the Pulumi community, referred to as "third-party" providers.
 
 ## Creating a Pulumi Terraform Bridge Provider
 
@@ -26,15 +30,15 @@ Pulumi offers this repository as a [GitHub template repository](https://docs.git
 
 1. Click "Use this template".
 1. Set the following options:
-    * Owner: pulumi (or your GitHub organization/username)
-    * Repository name: pulumi-foo (preface your provider with "pulumi" as standard practice)
+    * Owner: pulumi (third-party: your GitHub organization/username)
+    * Repository name: pulumi-foo (third-party: preface your repo name with "pulumi" as standard practice)
     * Description: Pulumi provider for Foo
     * Repository type: Public
 1. Clone the generated repository.
 
 From the templated repository:
 
-1. Run the following command to update files to use the name of your provider:
+1. Run the following command to update files to use the name of your provider (third-party: use your GitHub organization/username):
 
     ```bash
     make prepare NAME=foo REPOSITORY=github.com/pulumi/pulumi-foo
@@ -45,7 +49,7 @@ From the templated repository:
    - replace dependencies in `provider/go.mod` to reflect your repository name
    - find and replace all instances of the boilerplate `xyz` with the `NAME` of your provider.
 
-   Note for third-party (non-pulumi organization) providers:
+   Note for third-party providers:
    - Make sure to set the correct GitHub organization/username in all files referencing your provider as a dependency:
      - `examples/go.mod`
      - `provider/resources.go`


### PR DESCRIPTION
Add the storyline for third-party provider creation to README. Link to `deployment-templates`'s README instructions for releasing and publishing binaries.

Part of https://github.com/pulumi/home/issues/1997