### PR TITLE
fix: GitHub action fails due to incorrect job name reference

### DIFF
--- a/deployment-templates/release.yml
+++ b/deployment-templates/release.yml
@@ -29,7 +29,7 @@ env:
   PYPI_REPOSITORY_URL: ""
   PUBLISH_PYPI: true
 jobs:
-  publish-binary:
+  publish_binary:
     name: publish
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The job publish_sdk is referencing a job name using an underscore instead of a dash.