### PR TITLE
Corrected version of terraform-plugin-sdk replace in provider/go.mod

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
-	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 20220725190814-23001ad6ec03
+	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220725190814-23001ad6ec03
 	github.com/hashicorp/terraform-exec => github.com/hashicorp/terraform-exec v0.15.0
 )
 


### PR DESCRIPTION
Fixed issue where a previous PR introduced an incorrect version in `provider/go.mod`.