### PR TITLE
Use terraform-exec 0.17.2 now

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220725190814-23001ad6ec03
-	github.com/hashicorp/terraform-exec => github.com/hashicorp/terraform-exec v0.15.0
+	github.com/hashicorp/terraform-exec => github.com/hashicorp/terraform-exec v0.17.2
 )
 
 require (


### PR DESCRIPTION
The terraform-plugin-sdk requires functions from release 0.17.2 now, (tf.SetLogCore and tf.SetLog).