### PR TITLE
Add version to provider info

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -58,8 +58,8 @@ func Provider() tfbridge.ProviderInfo {
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{
 		// Instantiate the Terraform provider
-		P:    shimv2.NewProvider(xyz.New(version.Version)()),
-		Name: "xyz",
+		P:       shimv2.NewProvider(xyz.New(version.Version)()),
+		Name:    "xyz",
 		Version: version.Version,
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -60,6 +60,7 @@ func Provider() tfbridge.ProviderInfo {
 		// Instantiate the Terraform provider
 		P:    shimv2.NewProvider(xyz.New(version.Version)()),
 		Name: "xyz",
+		Version: version.Version,
 		// DisplayName is a way to be able to change the casing of the provider
 		// name when being displayed on the Pulumi registry
 		DisplayName: "",


### PR DESCRIPTION
A user hit this issue:
```
error: fatal: failed to Init GRPC to register RPC handlers: failed to create resource provider: ProviderInfo needs a semver-compatible version string, got info.Version=""
```

Bridged providers all seem to have it:
https://github.com/pulumi/pulumi-aws/blob/b5e02e8663502b28cc7bce5c326dc82822b1b718/provider/resources.go#L818C3-L818C37

https://github.com/pulumi/pulumi-gcp/blob/89c9fae772dcd8abc3b4908a203981aa77f8116b/provider/resources.go#L465