### PR TITLE
add: golangci-lint prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ensure the following tools are installed and present in your `$PATH`:
 
 - [`pulumictl`](https://github.com/pulumi/pulumictl#installation)
 - [Go 1.17](https://golang.org/dl/) or 1.latest
+- [`golangci-lint`](https://golangci-lint.run/welcome/install/)
 - [NodeJS](https://nodejs.org/en/) 14.x.  We recommend using [nvm](https://github.com/nvm-sh/nvm) to manage NodeJS installations.
 - [Yarn](https://yarnpkg.com/)
 - [TypeScript](https://www.typescriptlang.org/)


### PR DESCRIPTION
needed when running `make lint_provider`