### PR TITLE
Add redundant SDK files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,14 @@ provider/**/schema-embed.json
 **/version.txt
 **/nuget
 **/dist
+
+sdk/java/build
+sdk/java/.gradle
+sdk/java/gradle
+sdk/java/gradlew
+sdk/java/gradlew.bat
+
+sdk/python/venv
+
+go.work
+go.work.sum


### PR DESCRIPTION
should prevent issues like https://github.com/pulumi/pulumi-meraki/issues/1