### PR TITLE
Fix: Echo error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ prepare::
 	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi
 	@if test -z "${REPOSITORY}"; then echo "REPOSITORY not set"; exit 1; fi
 	@if test -z "${ORG}"; then echo "ORG not set"; exit 1; fi
-	@if test ! -d "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz"; then "Project already prepared"; exit 1; fi
+	@if test ! -d "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz"; then echo "Project already prepared"; exit 1; fi
 
 	mv "provider/cmd/pulumi-tfgen-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-tfgen-${NAME}
 	mv "provider/cmd/pulumi-resource-x${EMPTY_TO_AVOID_SED}yz" provider/cmd/pulumi-resource-${NAME}


### PR DESCRIPTION
Noticed this during a new project :)

It's calling the error message as if it's a command, and I assume this should have been echoed instead.


```
/bin/bash: Project already prepared: command not found
make: *** [prepare] Error 1
```