### PR TITLE
Fix `PluginDownloadURL` example path

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -124,7 +124,7 @@ func Provider() tfbridge.ProviderInfo {
 		LogoURL: "",
 		// PluginDownloadURL is an optional URL used to download the Provider
 		// for use in Pulumi programs
-		// e.g https://github.com/org/pulumi-provider-name/releases/
+		// e.g. https://github.com/org/pulumi-provider-name/releases/download/v${VERSION}/
 		PluginDownloadURL: "",
 		Description:       "A Pulumi package for creating and managing xyz cloud resources.",
 		// category/cloud tag helps with categorizing the package in the Pulumi Registry.


### PR DESCRIPTION
The example for `PluginDownloadURL` didn't work before adding path to a specific releases downloads.