### PR TITLE
Fix ci-mgmt: remove unread field `enableAutoRelease` from `.ci-mgmt.yaml`

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -48,8 +48,5 @@ publish:
 # Disables a pulumi-internal-only step for running create_docs_build during the release
 publishRegistry: false
 
-# Disables the pulumi-internal mechanism for auto-releasing after merging PRs with special labels.
-enableAutoRelease: false
-
 # For additional options, please refer to the defaults set in ci-mgmt:
 # https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/defaults.config.yaml

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@ PROVIDER_VERSION ?= 1.0.0-alpha.0+dev
 # Use this normalised version everywhere rather than the raw input to ensure consistency.
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 
+# Strips debug information from the provider binary to reduce its size and speed up builds
+LDFLAGS_STRIP_SYMBOLS=-s -w
 LDFLAGS_PROJ_VERSION=-X $(PROJECT)/$(VERSION_PATH)=$(VERSION_GENERIC)
 LDFLAGS_UPSTREAM_VERSION=
 LDFLAGS_EXTRAS=
-LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS)
+LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(LDFLAGS_STRIP_SYMBOLS)
 
 development: install_plugins provider build_sdks install_sdks
 


### PR DESCRIPTION
This PR removes the unused field `enableAutoRelease` from `.ci-mgmt.yaml`. [ci-mgmt](https://github.com/pulumi/ci-mgmt) recently started [rejecting](https://github.com/pulumi/ci-mgmt/pull/1126) unknown fields. This does not cause any change to the semantics of `.ci-mgmt.yaml`.

Part of https://github.com/pulumi/ci-mgmt/issues/1147