### PR TITLE
Update bridging instructions after we moved `/pf` to `/v3/pkg/pf`

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -73,29 +73,29 @@ func Provider() tfbridge.ProviderInfo {
 		//
 		//    - Remove the `shimv2` import and add:
 		//
-		//      	pfbridge "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
+		//      	pfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 		//
 		//    - Replace `shimv2.NewProvider` with `pfbridge.ShimProvider`.
 		//
 		//    - In provider/cmd/pulumi-tfgen-xyz/main.go, replace the
 		//      "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen" import with
-		//      "github.com/pulumi/pulumi-terraform-bridge/pf/tfgen". Remove the `version.Version`
+		//      "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen". Remove the `version.Version`
 		//      argument to `tfgen.Main`.
 		//
 		//    - In provider/cmd/pulumi-resource-xyz/main.go, replace the
 		//      "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge" import with
-		//      "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge". Replace the arguments to the
+		//      "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge". Replace the arguments to the
 		//      `tfbridge.Main` so it looks like this:
 		//
 		//      	tfbridge.Main(context.Background(), "xyz", xyz.Provider(),
 		//			tfbridge.ProviderMetadata{PulumiSchema: pulumiSchema})
 		//
 		//   Detailed instructions can be found at
-		//   https://github.com/pulumi/pulumi-terraform-bridge/blob/master/pf/README.md#how-to-upgrade-a-bridged-provider-to-plugin-framework.
+		//   https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/new-pf-provider.html
 		//   After that, you can proceed as normal.
 		//
 		// This is where you give the bridge a handle to the upstream terraform provider. SDKv2
-		// convention is to have a function at "github.com/iwahbe/terraform-provider-xyz/provider".New
+		// convention is to have a function at "github.com/pulumi/terraform-provider-xyz/provider".New
 		// which takes a version and produces a factory function. The provider you are bridging may
 		// not do that. You will need to find the function (generally called in upstream's main.go)
 		// that produces a:


### PR DESCRIPTION
This depends on https://github.com/pulumi/pulumi-terraform-bridge/pull/2734 merging for the docs link:

	https://pulumi-developer-docs.readthedocs.io/projects/pulumi-terraform-bridge/en/latest/docs/guides/new-pf-provider.html

Fixes #169