### PR TITLE
Set pulumictl to v0.0.48

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -50,3 +50,6 @@ publishRegistry: false
 
 # For additional options, please refer to the defaults set in ci-mgmt:
 # https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/defaults.config.yaml
+
+toolVersions:
+  pulumictl: "v0.0.48"

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -42,7 +42,7 @@ runs:
       if: inputs.tools == 'all' || contains(inputs.tools, 'pulumictl')
       uses: jaxxstorm/action-install-gh-release@cd6b2b78ad38bdd294341cda064ec0692b06215b # v1.14.0
       with:
-        tag: v0.0.46
+        tag: v0.0.48
         repo: pulumi/pulumictl
 
     - name: Install Pulumi CLI

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PULUMI_PROVIDER_BUILD_PARALLELISM ?=
 PULUMI_CONVERT := 1
 PULUMI_MISSING_DOCS_ERROR := true
 
-PULUMICTL_VERSION := v0.0.46
+PULUMICTL_VERSION := v0.0.48
 PULUMICTL := $(shell which pulumictl || \
 	(test ! -e $(WORKING_DIR)/bin/pulumictl && \
 		GOPATH="$(WORKING_DIR)" go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"; \


### PR DESCRIPTION
This change incorporates a version of pulumictl that can be built from source, according to changes in https://github.com/pulumi/pulumictl/pull/89.

Fixes https://github.com/pulumi/pulumi-tf-provider-boilerplate/issues/201
