### PR TITLE
fix: Improve compatibility for new users

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -8,7 +8,7 @@ This repository is initially set up as a fictitious provider named "xyz" to demo
 
 Ensure the following tools are installed and present in your `$PATH`:
 
-- [mise](https://mise.jdx.dev/getting-started.html)
+- [`mise`](https://mise.jdx.dev/getting-started.html)
 - [`pulumictl`](https://github.com/pulumi/pulumictl#installation)
 - [Go](https://golang.org/dl/) or 1.latest
 - [`golangci-lint`](https://golangci-lint.run/welcome/install/)

--- a/SETUP.md
+++ b/SETUP.md
@@ -8,6 +8,7 @@ This repository is initially set up as a fictitious provider named "xyz" to demo
 
 Ensure the following tools are installed and present in your `$PATH`:
 
+- [mise](https://mise.jdx.dev/getting-started.html)
 - [`pulumictl`](https://github.com/pulumi/pulumictl#installation)
 - [Go](https://golang.org/dl/) or 1.latest
 - [`golangci-lint`](https://golangci-lint.run/welcome/install/)

--- a/setup.sh
+++ b/setup.sh
@@ -130,8 +130,9 @@ fi
 OS=$(uname)
 sed_inplace() {
   if [[ "${OS}" == "Darwin" ]]; then
-    # In MacOS the -i parameter needs an empty string to execute in place.
-    sed -i '' "${2}" "${1}" &> /dev/null
+    # If this is macOS, explicitly use BSD sed from /usr/bin to avoid issues
+    # with GNU sed installed via Homebrew.
+    /usr/bin/sed -i '' "${2}" "${1}" &> /dev/null
   else
     sed -i "${2}" "${1}" &> /dev/null
   fi


### PR DESCRIPTION
* [X] Explicitly list the dependency on `mise`.
* [X] You cannot assume that `sed` on macOS is the BSD flavor. You need to explicitly point to the path for the BSD version.